### PR TITLE
Set up dummy data for testing of readers and articles tables and created the SQL database

### DIFF
--- a/School Blog project/Database/create_database.sql
+++ b/School Blog project/Database/create_database.sql
@@ -1,0 +1,43 @@
+-- Creates the application's database and basic tables used by the project.
+-- Adjust names/types to match your EF Core model if needed.
+
+IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = N'aspnet-School_Blog_project')
+BEGIN
+    CREATE DATABASE [aspnet-School_Blog_project];
+END
+GO
+
+USE [aspnet-School_Blog_project];
+GO
+
+-- Readers table (custom, separate from ASP.NET Identity tables)
+IF OBJECT_ID('dbo.Readers') IS NULL
+BEGIN
+    CREATE TABLE dbo.Readers (
+        UserID INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        Username NVARCHAR(50) NOT NULL,
+        Password NVARCHAR(25) NOT NULL,
+        IsWriter BIT NOT NULL CONSTRAINT DF_Readers_IsWriter DEFAULT (0),
+        IsEditor BIT NOT NULL CONSTRAINT DF_Readers_IsEditor DEFAULT (0)
+    );
+END
+GO
+
+-- Article table
+IF OBJECT_ID('dbo.Article') IS NULL
+BEGIN
+    CREATE TABLE dbo.Article (
+        ArticleID INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        Title NVARCHAR(MAX) NOT NULL,
+        Author NVARCHAR(256) NULL,
+        DatePublished DATETIME2 NOT NULL CONSTRAINT DF_Article_DatePublished DEFAULT (SYSUTCDATETIME()),
+        ArticleImagePath NVARCHAR(512) NULL
+    );
+END
+GO
+
+-- Note: ASP.NET Identity tables are created by EF migrations if you use IdentityDbContext.
+-- Use this script to create the database and basic custom tables. Run it with SQL Server Management Studio,
+-- SQL Server Object Explorer in Visual Studio, or sqlcmd. Administrators should update the
+-- IsWriter/IsEditor columns directly (e.g. UPDATE dbo.Readers SET IsWriter = 1 WHERE UserID = 1) rather
+-- than allowing users to change these flags from the app UI.

--- a/School Blog project/Database/seed_dev.sql
+++ b/School Blog project/Database/seed_dev.sql
@@ -1,0 +1,41 @@
+-- DEV ONLY: seed data for local testing. DO NOT use in production.
+USE [aspnet-School_Blog_project];
+GO
+
+-- Readers (passwords are placeholders — do not use real passwords)
+INSERT INTO dbo.Readers (Username, Password, IsWriter, IsEditor) VALUES
+('dev_alice', 'dev_pass_1', 1, 0),
+('dev_bob',   'dev_pass_2', 0, 1),
+('dev_carol', 'dev_pass_3', 0, 0),
+('test_writer','dev_pass_4', 1, 0),
+('test_editor','dev_pass_5', 0, 1),
+('test_both','dev_pass_6', 1, 1);
+GO
+
+-- Articles linked to the dummy readers
+INSERT INTO dbo.Article (Title, Author, DatePublished, ArticleImagePath) VALUES
+('DEV: Welcome to the School Blog', 'dev_alice', SYSUTCDATETIME(), NULL),
+('DEV: Editorial Guidelines', 'dev_bob', SYSUTCDATETIME(), NULL),
+('DEV: Student Spotlight', 'dev_alice', SYSUTCDATETIME(), NULL),
+('DEV: Test Article - Writer', 'test_writer', SYSUTCDATETIME(), NULL),
+('DEV: Test Article - Editor', 'test_editor', SYSUTCDATETIME(), NULL);
+GO
+
+-- Admin-only examples: change permissions explicitly
+-- Grant writer to carol
+UPDATE dbo.Readers SET IsWriter = 1 WHERE Username = 'dev_carol';
+GO
+
+-- Revoke editor from test_both
+UPDATE dbo.Readers SET IsEditor = 0 WHERE Username = 'test_both';
+GO
+
+-- Quick verification queries
+SELECT UserID, Username, IsWriter, IsEditor FROM dbo.Readers ORDER BY UserID;
+SELECT TOP(20) ArticleID, Title, Author, DatePublished FROM dbo.Article ORDER BY DatePublished DESC;
+GO
+
+-- Cleanup helpers for automated tests (safe patterns for dev-only cleanup)
+DELETE FROM dbo.Article WHERE Title LIKE 'DEV:%' OR Title LIKE 'DEV %' OR Title LIKE 'Test%';
+DELETE FROM dbo.Readers WHERE Username LIKE 'dev_%' OR Username LIKE 'test_%';
+GO

--- a/School Blog project/Properties/serviceDependencies.local.json
+++ b/School Blog project/Properties/serviceDependencies.local.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "mssql1": {
+      "secretStore": null,
+      "resourceId": null,
       "type": "mssql.local",
       "connectionId": "ConnectionStrings:DefaultConnection"
     }


### PR DESCRIPTION
Closes #4 

This pull request introduces the initial SQL Server database setup and development seed data for the School Blog project. It adds scripts to create the core custom tables (`Readers` and `Article`), provides a development-only seed script with sample users and articles, and makes minor configuration changes for local database development.

**Database Initialization and Seeding**

* Added `create_database.sql` to create the `aspnet-School_Blog_project` database, along with the custom `Readers` and `Article` tables, including default values and constraints.
* Added `seed_dev.sql` for development environments, which seeds test users with various roles and test articles, and includes SQL for modifying roles and cleaning up seeded data.

**Development Configuration**

* Updated `serviceDependencies.local.json` to add `secretStore` and `resourceId` fields (set to `null`) for the local MSSQL service dependency, supporting local development tooling.