### PR TITLE
Switch to custom ApplicationUser and add roles support

### DIFF
--- a/School Blog project/Data/ApplicationDbContext.cs
+++ b/School Blog project/Data/ApplicationDbContext.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using School_Blog_project.Models;
 
 namespace School_Blog_project.Data
 {
-	public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext(options)
+	public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext<ApplicationUser>(options)
 	{
+		public DbSet<Article> Articles { get; set; } = null!;
 	}
 }

--- a/School Blog project/Data/ApplicationUser.cs
+++ b/School Blog project/Data/ApplicationUser.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace School_Blog_project.Data
+{
+	public class ApplicationUser : IdentityUser
+	{
+		public bool IsWriter { get; set; }
+
+		public bool IsEditor { get; set; }
+	}
+}

--- a/School Blog project/Program.cs
+++ b/School Blog project/Program.cs
@@ -2,35 +2,38 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using School_Blog_project.Data;
 
-var builder = WebApplication.CreateBuilder(args);
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+string connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
 	options.UseSqlServer(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
-builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = false)
+	.AddRoles<IdentityRole>()
 	.AddEntityFrameworkStores<ApplicationDbContext>();
+builder.Services.AddRazorPages();
 builder.Services.AddControllersWithViews();
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-	app.UseMigrationsEndPoint();
+	_ = app.UseMigrationsEndPoint();
 }
 else
 {
-	app.UseExceptionHandler("/Home/Error");
+	_ = app.UseExceptionHandler("/Home/Error");
 	// The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-	app.UseHsts();
+	_ = app.UseHsts();
 }
 
 app.UseHttpsRedirection();
 app.UseRouting();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapStaticAssets();

--- a/School Blog project/SeedDataBase.cs
+++ b/School Blog project/SeedDataBase.cs
@@ -1,0 +1,6 @@
+﻿namespace School_Blog_project
+{
+	public static class SeedDataBase
+	{
+	}
+}


### PR DESCRIPTION
Closes #7 

Updated ApplicationDbContext to use ApplicationUser and added DbSet<Article>. Switched identity setup to use ApplicationUser with roles and disabled confirmed account requirement. Introduced ApplicationUser class with IsWriter and IsEditor properties. Added placeholder SeedDataBase class for future seeding logic.