### PR TITLE
Update _LoginPartial to use ApplicationUser for Identity

### DIFF
--- a/School Blog project/Views/Shared/_LoginPartial.cshtml
+++ b/School Blog project/Views/Shared/_LoginPartial.cshtml
@@ -1,6 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Identity
-@inject SignInManager<IdentityUser> SignInManager
-@inject UserManager<IdentityUser> UserManager
+@using School_Blog_project.Data
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
 
 <ul class="navbar-nav">
 @if (SignInManager.IsSignedIn(User))


### PR DESCRIPTION
The issue was in `_LoginPartial.cshtml`. Switched SignInManager and UserManager to use ApplicationUser instead of IdentityUser. Added using statement for School_Blog_project.Data to support the new user class.

Closes #32