### PR TITLE
Moved Dummy data into DB Context

### DIFF
--- a/School Blog project/Data/ApplicationDbContext.cs
+++ b/School Blog project/Data/ApplicationDbContext.cs
@@ -2,10 +2,37 @@
 using Microsoft.EntityFrameworkCore;
 using School_Blog_project.Models;
 
+#pragma warning disable CA1707 // Identifiers should not contain underscores
 namespace School_Blog_project.Data
 {
 	public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext<ApplicationUser>(options)
 	{
 		public DbSet<Article> Articles { get; set; } = null!;
+		public DbSet<Reader> Readers { get; set; } = null!;
+
+		protected override void OnModelCreating(ModelBuilder builder)
+		{
+			base.OnModelCreating(builder);
+
+			// Seed Readers (matches Database/seed_dev.sql inserts and subsequent updates)
+			_ = builder.Entity<Reader>().HasData(
+				new Reader { UserID = 1, Username = "dev_alice", Password = "dev_pass_1", IsWriter = true, IsEditor = false },
+				new Reader { UserID = 2, Username = "dev_bob", Password = "dev_pass_2", IsWriter = false, IsEditor = true },
+				new Reader { UserID = 3, Username = "dev_carol", Password = "dev_pass_3", IsWriter = true, IsEditor = false }, // granted writer in SQL update
+				new Reader { UserID = 4, Username = "test_writer", Password = "dev_pass_4", IsWriter = true, IsEditor = false },
+				new Reader { UserID = 5, Username = "test_editor", Password = "dev_pass_5", IsWriter = false, IsEditor = true },
+				new Reader { UserID = 6, Username = "test_both", Password = "dev_pass_6", IsWriter = true, IsEditor = false } // editor revoked in SQL update
+			);
+
+			// Seed Articles (uses fixed DatePublished values to mirror SYSUTCDATETIME at insert time)
+			DateTime now = DateTime.UtcNow;
+			_ = builder.Entity<Article>().HasData(
+				new Article { ArticleID = 1, Title = "DEV: Welcome to the School Blog", Author = "dev_alice", DatePublished = now, ArticleImagePath = null },
+				new Article { ArticleID = 2, Title = "DEV: Editorial Guidelines", Author = "dev_bob", DatePublished = now, ArticleImagePath = null },
+				new Article { ArticleID = 3, Title = "DEV: Student Spotlight", Author = "dev_alice", DatePublished = now, ArticleImagePath = null },
+				new Article { ArticleID = 4, Title = "DEV: Test Article - Writer", Author = "test_writer", DatePublished = now, ArticleImagePath = null },
+				new Article { ArticleID = 5, Title = "DEV: Test Article - Editor", Author = "test_editor", DatePublished = now, ArticleImagePath = null }
+			);
+		}
 	}
 }

--- a/School Blog project/School Blog project/Models/Reader.cs
+++ b/School Blog project/School Blog project/Models/Reader.cs
@@ -1,0 +1,16 @@
+namespace School_Blog_project.Models
+{
+	public class Reader
+	{
+		public int UserID { get; set; }
+
+		public required string Username { get; set; }
+
+		// NOTE: Passwords in seed data are placeholders for development only
+		public string? Password { get; set; }
+
+		public bool IsWriter { get; set; }
+
+		public bool IsEditor { get; set; }
+	}
+}


### PR DESCRIPTION
This pull request introduces a new `Reader` model and updates the database context to support it, along with seeding development data for both readers and articles. These changes lay the groundwork for managing different user roles (writers and editors) and provide initial data for development and testing.

**Database model and seeding updates:**

* Added a new `Reader` entity with properties for user ID, username, password, and role flags (`IsWriter`, `IsEditor`) in `Reader.cs`.
* Updated `ApplicationDbContext` to include a `DbSet<Reader>`, and implemented `OnModelCreating` to seed initial development data for both `Reader` and `Article` entities. This ensures the database is pre-populated with sample users and articles matching the development SQL scripts.