### PR TITLE
Create article list page skeletons

### DIFF
--- a/School Blog project/Models/ArticleSummary.cs
+++ b/School Blog project/Models/ArticleSummary.cs
@@ -2,6 +2,12 @@
 {
 	public class ArticleSummary
 	{
-		
+		public required string Title { get; set; }
+		public required DateTime Date { get; set; }
+		public string? Description { get; set; }
+		public string? ImageUrl { get; set; }
+
+		// Support multiple categories
+		public List<string> Categories { get; set; } = new();
 	}
 }

--- a/School Blog project/Models/ArticleSummary.cs
+++ b/School Blog project/Models/ArticleSummary.cs
@@ -1,0 +1,7 @@
+﻿namespace School_Blog_project.Models
+{
+	public class ArticleSummary
+	{
+		
+	}
+}

--- a/School Blog project/Views/Home/Faculty.cshtml
+++ b/School Blog project/Views/Home/Faculty.cshtml
@@ -1,5 +1,15 @@
 ﻿@{
     ViewData["Title"] = "Faculty";
+    ViewData["SelectedCategory"] = "Faculty";
 }
-<h1>Faculty &amp; Staff Stories</h1>
-<p>Placeholder page for Faculty &amp; Staff Stories.</p>
+
+<div class="row">
+    <div class="col-12 col-md-8">
+        @Html.Partial("_ArticleList")  <!-- will render placeholders until model is provided -->
+    </div>
+
+    <aside class="col-12 col-md-4">
+        @Html.Partial("_NewsArchives")
+        @Html.Partial("_MediaContact")
+    </aside>
+</div>

--- a/School Blog project/Views/Home/Graduates.cshtml
+++ b/School Blog project/Views/Home/Graduates.cshtml
@@ -1,5 +1,15 @@
 ﻿@{
     ViewData["Title"] = "Graduates";
+    ViewData["SelectedCategory"] = "Graduates";
 }
-<h1>Graduate Stories</h1>
-<p>Placeholder page for Graduate Stories.</p>
+
+<div class="row">
+    <div class="col-12 col-md-8">
+        @Html.Partial("_ArticleList")  <!-- will render placeholders until model is provided -->
+    </div>
+
+    <aside class="col-12 col-md-4">
+        @Html.Partial("_NewsArchives")
+        @Html.Partial("_MediaContact")
+    </aside>
+</div>

--- a/School Blog project/Views/Home/News.cshtml
+++ b/School Blog project/Views/Home/News.cshtml
@@ -1,5 +1,15 @@
 ﻿@{
     ViewData["Title"] = "News";
+    ViewData["SelectedCategory"] = "All";
 }
-<h1>News</h1>
-<p>Placeholder page for News.</p>
+
+<div class="row">
+    <div class="col-12 col-md-8">
+        @Html.Partial("_ArticleList")
+    </div>
+
+    <aside class="col-12 col-md-4">
+        @Html.Partial("_NewsArchives")
+        @Html.Partial("_MediaContact")
+    </aside>
+</div>

--- a/School Blog project/Views/Home/Students.cshtml
+++ b/School Blog project/Views/Home/Students.cshtml
@@ -1,5 +1,15 @@
 ﻿@{
     ViewData["Title"] = "Students";
+    ViewData["SelectedCategory"] = "Students";
 }
-<h1>Student Stories</h1>
-<p>Placeholder page for Student Stories.</p>
+
+<div class="row">
+    <div class="col-12 col-md-8">
+        @Html.Partial("_ArticleList")  <!-- will render placeholders until model is provided -->
+    </div>
+
+    <aside class="col-12 col-md-4">
+        @Html.Partial("_NewsArchives")
+        @Html.Partial("_MediaContact")
+    </aside>
+</div>

--- a/School Blog project/Views/Shared/_ArticleList.cshtml
+++ b/School Blog project/Views/Shared/_ArticleList.cshtml
@@ -1,0 +1,5 @@
+﻿@*
+    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+*@
+@{
+}

--- a/School Blog project/Views/Shared/_ArticleList.cshtml
+++ b/School Blog project/Views/Shared/_ArticleList.cshtml
@@ -1,5 +1,74 @@
-﻿@*
-    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-*@
+﻿@using School_Blog_project.Models
+@model IEnumerable<ArticleSummary>?
+
 @{
+    var category = ViewData["SelectedCategory"] as string ?? "All";
+    var startYear = 2013;
+    var currentYear = DateTime.Now.Year;
+    var items = Model;
+    var usePlaceholders = items == null || !items.Any();
+    var placeholderCount = 6;
+    var heading = category == "All" ? "News" : $"{category} Stories";
 }
+
+<div>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="mb-0">@heading</h1>
+    </div>
+
+    <div class="list-group mb-4">
+        @if (usePlaceholders)
+        {
+            for (int i = 1; i <= placeholderCount; i++)
+            {
+                <article class="list-group-item list-group-item-action mb-3">
+                    <div class="row g-3">
+                        <div class="col-12 col-sm-3 d-flex align-items-center justify-content-center">
+                            <div class="bg-secondary text-white d-flex align-items-center justify-content-center" style="width:120px;height:80px;">
+                                Image
+                            </div>
+                        </div>
+                        <div class="col-12 col-sm-9">
+                            <h5 class="mb-1">Article Title Placeholder @i</h5>
+                            <small class="text-muted">January 1, @currentYear</small>
+                            <p class="mb-1 mt-2 text-muted">Short excerpt placeholder text to show layout only.</p>
+                            <a class="btn btn-outline-primary btn-sm" href="#" onclick="return false;">Read more</a>
+                        </div>
+                    </div>
+                </article>
+            }
+        }
+        else
+        {
+            foreach (var a in items)
+            {
+                <article class="list-group-item list-group-item-action mb-3">
+                    <div class="row g-3">
+                        <div class="col-12 col-sm-3 d-flex align-items-center justify-content-center">
+                            <div class="bg-secondary text-white d-flex align-items-center justify-content-center" style="width:120px;height:80px;">
+                                @(!string.IsNullOrEmpty(a.ImageUrl) ? "Image" : "Image")
+                            </div>
+                        </div>
+                        <div class="col-12 col-sm-9">
+                            <h5 class="mb-1">@a.Title</h5>
+                            <small class="text-muted">@a.Date.ToString("MMMM d, yyyy")</small>
+                            <p class="mb-1 mt-2 text-muted">@a.Description</p>
+                            <a class="btn btn-outline-primary btn-sm" href="#" onclick="return false;">Read more</a>
+                        </div>
+                    </div>
+                </article>
+            }
+        }
+    </div>
+
+    <!-- Pagination placeholder -->
+    <nav aria-label="Pagination">
+        <ul class="pagination">
+            <li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" onclick="return false;">Previous</a></li>
+            <li class="page-item active"><a class="page-link" href="#" onclick="return false;">1</a></li>
+            <li class="page-item"><a class="page-link" href="#" onclick="return false;">2</a></li>
+            <li class="page-item"><a class="page-link" href="#" onclick="return false;">3</a></li>
+            <li class="page-item"><a class="page-link" href="#" onclick="return false;">Next</a></li>
+        </ul>
+    </nav>
+</div>

--- a/School Blog project/Views/Shared/_MediaContact.cshtml
+++ b/School Blog project/Views/Shared/_MediaContact.cshtml
@@ -1,0 +1,5 @@
+﻿@*
+    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+*@
+@{
+}

--- a/School Blog project/Views/Shared/_MediaContact.cshtml
+++ b/School Blog project/Views/Shared/_MediaContact.cshtml
@@ -1,5 +1,9 @@
-﻿@*
-    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-*@
-@{
-}
+﻿<div class="card">
+    <div class="card-header">Media Contact</div>
+    <div class="card-body">
+        <h6 class="card-title mb-1">Media Relations</h6>
+        <p class="small text-muted mb-1">Jane Doe</p>
+        <p class="small text-muted mb-1">Phone: (555) 555-5555</p>
+        <p class="small text-muted mb-0">Email: <a href="mailto:media@example.edu">media@example.edu</a></p>
+    </div>
+</div>

--- a/School Blog project/Views/Shared/_NewsArchives.cshtml
+++ b/School Blog project/Views/Shared/_NewsArchives.cshtml
@@ -1,0 +1,5 @@
+﻿@*
+    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+*@
+@{
+}

--- a/School Blog project/Views/Shared/_NewsArchives.cshtml
+++ b/School Blog project/Views/Shared/_NewsArchives.cshtml
@@ -1,5 +1,13 @@
-﻿@*
-    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-*@
-@{
+﻿@{
+    var startYear = 2013;
+    var currentYear = DateTime.Now.Year;
 }
+<div class="card mb-3">
+    <div class="card-header">News Archives</div>
+    <ul class="list-group list-group-flush">
+        @for (int y = currentYear; y >= startYear; y--)
+        {
+            <li class="list-group-item"><a href="#" class="text-decoration-none" onclick="return false;">@y</a></li>
+        }
+    </ul>
+</div>


### PR DESCRIPTION
Closes #20 
Closes #22 
Closes #24 
Closes #26

This pull request introduces a new `ArticleSummary` model and significantly updates the blog's News, Faculty, Graduates, and Students pages to support dynamic article listings and improved layout. It adds shared partial views for displaying article lists, news archives, and media contact information, replacing the previous placeholder content and preparing the site for future data integration.

**Model Addition:**

* Added `ArticleSummary.cs` to represent articles, supporting title, date, description, image URL, and multiple categories.

**View Refactoring and Layout Improvements:**

* Updated `News.cshtml`, `Faculty.cshtml`, `Graduates.cshtml`, and `Students.cshtml` to use a consistent two-column layout, render the `_ArticleList` partial for article display, and include sidebars with news archives and media contact information. [[1]](diffhunk://#diff-3b0c94e4e1324b72f865198b77458bf2fd38677967ff84f9cb212a51936c5e8dR3-R15) [[2]](diffhunk://#diff-7a5fdbe826162d3e42005a2b3639705ee6b1ff43c88c7e41ae0ed0941a2fddc5R3-R15) [[3]](diffhunk://#diff-f1d9fb17cdf746b1a9640e2d16765596693ad668349b55e64bca1e4c4fdc5093R3-R15) [[4]](diffhunk://#diff-36934935b0493f757fccb779343afe94b035335f4801082ee818a2413e8b0003R3-R15)

**New Shared Partials for Reusability:**

* Added `_ArticleList.cshtml` partial to display either placeholder or real articles, with support for category headings and pagination UI.
* Added `_NewsArchives.cshtml` partial to display a list of years for news archives.
* Added `_MediaContact.cshtml` partial to show media contact information in the sidebar.