### PR TITLE
Switch to role-based authorization for user permissions

### DIFF
--- a/School Blog project/Areas/Identity/Pages/Account/Register.cshtml
+++ b/School Blog project/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,0 +1,21 @@
+@page
+@model School_Blog_project.Areas.Identity.Pages.Account.RegisterModel
+
+<form method="post">
+    <div class="form-group">
+        <label asp-for="Input.Email"></label>
+        <input asp-for="Input.Email" class="form-control" />
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Input.Password"></label>
+        <input asp-for="Input.Password" class="form-control" />
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Input.ConfirmPassword"></label>
+        <input asp-for="Input.ConfirmPassword" class="form-control" />
+        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Register</button>
+</form>

--- a/School Blog project/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/School Blog project/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using School_Blog_project.Data;
+using System.ComponentModel.DataAnnotations;
+
+namespace School_Blog_project.Areas.Identity.Pages.Account
+{
+	[AllowAnonymous]
+	public class RegisterModel(
+		UserManager<ApplicationUser> userManager,
+		SignInManager<ApplicationUser> signInManager,
+		ILogger<RegisterModel> logger) : PageModel
+	{
+		private readonly SignInManager<ApplicationUser> _signInManager = signInManager;
+		private readonly UserManager<ApplicationUser> _userManager = userManager;
+		private readonly ILogger<RegisterModel> _logger = logger;
+
+		[BindProperty]
+		public InputModel Input { get; set; } = null!;
+
+		public string? ReturnUrl { get; set; }
+
+		public class InputModel
+		{
+			[Required]
+			[EmailAddress]
+			[Display(Name = "Email")]
+			public string Email { get; set; } = null!;
+
+			[Required]
+			[DataType(DataType.Password)]
+			[Display(Name = "Password")]
+			public string Password { get; set; } = null!;
+
+			[DataType(DataType.Password)]
+			[Display(Name = "Confirm password")]
+			[Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+			public string ConfirmPassword { get; set; } = null!;
+		}
+
+		public void OnGet(string? returnUrl = null)
+		{
+			ReturnUrl = returnUrl;
+		}
+
+		public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+		{
+			returnUrl ??= Url.Content("~/");
+			if (ModelState.IsValid)
+			{
+				ApplicationUser user = new() { UserName = Input.Email, Email = Input.Email, EmailConfirmed = true };
+				IdentityResult result = await _userManager.CreateAsync(user, Input.Password);
+				if (result.Succeeded)
+				{
+#pragma warning disable CA2254 // Template should be a static expression
+#pragma warning disable CA1848 // Use the LoggerMessage delegates
+					_logger.LogInformation("User created a new account with password.");
+#pragma warning restore CA1848 // Use the LoggerMessage delegates
+#pragma warning restore CA2254
+
+					// Ensure the default Reader role exists and assign it to the new user
+					const string defaultRole = "Reader";
+					if (!await _userManager.IsInRoleAsync(user, defaultRole))
+					{
+						// Role creation is handled at startup; try to add role membership here
+						_ = await _userManager.AddToRoleAsync(user, defaultRole);
+					}
+
+					await _signInManager.SignInAsync(user, isPersistent: false);
+					return LocalRedirect(returnUrl);
+				}
+				foreach (IdentityError error in result.Errors)
+				{
+					ModelState.AddModelError(string.Empty, error.Description);
+				}
+			}
+
+			// If we got this far, something failed, redisplay form
+			return Page();
+		}
+	}
+}

--- a/School Blog project/Authorization/IsWriterHandler.cs
+++ b/School Blog project/Authorization/IsWriterHandler.cs
@@ -6,6 +6,8 @@ namespace School_Blog_project.Authorization
 {
 	public class IsWriterHandler(UserManager<ApplicationUser> userManager) : AuthorizationHandler<IsWriterRequirement>
 	{
+		private readonly UserManager<ApplicationUser> _userManager = userManager;
+
 		protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, IsWriterRequirement requirement)
 		{
 			if (context.User?.Identity == null || !context.User.Identity.IsAuthenticated)
@@ -13,8 +15,8 @@ namespace School_Blog_project.Authorization
 				return;
 			}
 
-			ApplicationUser? user = await userManager.GetUserAsync(context.User);
-			if (user != null && user.IsWriter)
+			ApplicationUser? user = await _userManager.GetUserAsync(context.User);
+			if (user != null && await _userManager.IsInRoleAsync(user, "Writer"))
 			{
 				context.Succeed(requirement);
 			}

--- a/School Blog project/Data/AdminSeeder.cs
+++ b/School Blog project/Data/AdminSeeder.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace School_Blog_project.Data
+{
+	/// <summary>
+	/// Helper to provision initial roles and admin users for a deployment.
+	/// This file is intentionally not invoked automatically from Program.cs; teams can
+	/// edit the static <see cref="SeedAsync"/> method to declare which accounts/roles
+	/// should be created for their environment and then run it from a deployment
+	/// script or a one-off admin tool.
+	/// </summary>
+	public static class AdminSeeder
+	{
+		/// <summary>
+		/// Seed roles and users. The implementation below is an example: it creates
+		/// the roles Reader, Writer and Editor and ensures a sample guest account exists.
+		/// Edit the <see cref="initialAccounts"/> array to declare the accounts you want
+		/// provisioned for a given deployment.
+		/// </summary>
+		public static async Task SeedAsync(IServiceProvider services)
+		{
+			using IServiceScope scope = services.CreateScope();
+			RoleManager<IdentityRole> roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+			UserManager<ApplicationUser> userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+			// Roles to ensure exist
+			string[] roles = ["Reader", "Writer", "Editor"];
+			foreach (string? role in roles)
+			{
+				if (!await roleManager.RoleExistsAsync(role))
+				{
+					_ = await roleManager.CreateAsync(new IdentityRole(role));
+				}
+			}
+
+			// Define initial accounts to create. Edit as needed for your deployment.
+			var initialAccounts = new[]
+			{
+				new
+				{
+					Email = "Guest@Guest.com",
+					Password = "P@ssw0rd",
+					Roles = new[] { "Reader", "Writer", "Editor" }
+				}
+			};
+
+			foreach (var acct in initialAccounts)
+			{
+				ApplicationUser? existing = await userManager.FindByEmailAsync(acct.Email);
+				if (existing == null)
+				{
+					ApplicationUser user = new() { UserName = acct.Email, Email = acct.Email, EmailConfirmed = true };
+					IdentityResult createResult = await userManager.CreateAsync(user, acct.Password);
+					if (createResult.Succeeded)
+					{
+						_ = await userManager.AddToRolesAsync(user, acct.Roles);
+					}
+				}
+				else
+				{
+					// ensure roles
+					foreach (string? r in acct.Roles)
+					{
+						if (!await userManager.IsInRoleAsync(existing, r))
+						{
+							_ = await userManager.AddToRoleAsync(existing, r);
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/School Blog project/Data/ApplicationDbContext.cs
+++ b/School Blog project/Data/ApplicationDbContext.cs
@@ -17,9 +17,9 @@ namespace School_Blog_project.Data
 		public DbSet<Article> Articles { get; set; } = null!;
 
 		/// <summary>
-		/// DbSet for reader seed records.
+        /// DbSet for reader seed records.
 		/// </summary>
-		public DbSet<Reader> Readers { get; set; } = null!;
+		public DbSet<School_Blog_project.Models.Reader> Readers { get; set; } = null!;
 
 		public DbSet<ArticleCatagory> ArticleCatagories { get; set; } = null!;
 		public DbSet<Categories> Categories { get; set; } = null!;

--- a/School Blog project/Data/ApplicationUser.cs
+++ b/School Blog project/Data/ApplicationUser.cs
@@ -7,14 +7,6 @@ namespace School_Blog_project.Data
 	/// </summary>
 	public class ApplicationUser : IdentityUser
 	{
-		/// <summary>
-		/// Indicates whether the user is permitted to create articles.
-		/// </summary>
-		public bool IsWriter { get; set; }
-
-		/// <summary>
-		/// Indicates whether the user is permitted to edit or approve articles.
-		/// </summary>
-		public bool IsEditor { get; set; }
+		// Role membership is used instead of boolean flags (Writer, Editor)
 	}
 }

--- a/School Blog project/Data/Migrations/20260417120000_RemoveAspNetUsersRoleBools.cs
+++ b/School Blog project/Data/Migrations/20260417120000_RemoveAspNetUsersRoleBools.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace School_Blog_project.Data.Migrations
+{
+	public partial class RemoveAspNetUsersRoleBools : Migration
+	{
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.DropColumn(
+				name: "IsEditor",
+				table: "AspNetUsers");
+
+			migrationBuilder.DropColumn(
+				name: "IsWriter",
+				table: "AspNetUsers");
+		}
+
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.AddColumn<bool>(
+				name: "IsEditor",
+				table: "AspNetUsers",
+				type: "bit",
+				nullable: false,
+				defaultValue: false);
+
+			migrationBuilder.AddColumn<bool>(
+				name: "IsWriter",
+				table: "AspNetUsers",
+				type: "bit",
+				nullable: false,
+				defaultValue: false);
+		}
+	}
+}

--- a/School Blog project/Data/RoleSeeder.cs
+++ b/School Blog project/Data/RoleSeeder.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace School_Blog_project.Data
+{
+	/// <summary>
+	/// Ensures application roles exist. This runs at startup to create the minimal set
+	/// of roles (Reader, Writer, Editor). Admin account provisioning remains in
+	/// <see cref="AdminSeeder"/> so deployments can manage initial users separately.
+	/// </summary>
+	public class RoleSeeder(RoleManager<IdentityRole> roleManager)
+	{
+		private readonly RoleManager<IdentityRole> _roleManager = roleManager;
+
+		public async Task SeedAsync(params string[] roles)
+		{
+			foreach (string role in roles)
+			{
+				if (!await _roleManager.RoleExistsAsync(role))
+				{
+					_ = await _roleManager.CreateAsync(new IdentityRole(role));
+				}
+			}
+		}
+	}
+}

--- a/School Blog project/Database/create_database.sql
+++ b/School Blog project/Database/create_database.sql
@@ -16,9 +16,9 @@ BEGIN
     CREATE TABLE dbo.Readers (
         UserID INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
         Username NVARCHAR(50) NOT NULL,
-        Password NVARCHAR(25) NOT NULL,
-        IsWriter BIT NOT NULL CONSTRAINT DF_Readers_IsWriter DEFAULT (0),
-        IsEditor BIT NOT NULL CONSTRAINT DF_Readers_IsEditor DEFAULT (0)
+        Password NVARCHAR(25) NOT NULL
+        -- NOTE: Role membership is now managed by ASP.NET Identity (AspNetRoles / AspNetUserRoles).
+        -- The IsWriter/IsEditor boolean columns were removed in favor of role-based authorization.
     );
 END
 GO

--- a/School Blog project/Database/seed_dev.sql
+++ b/School Blog project/Database/seed_dev.sql
@@ -26,8 +26,8 @@ GO
 UPDATE dbo.Readers SET IsWriter = 1 WHERE Username = 'dev_carol';
 GO
 
--- Revoke editor from test_both
-UPDATE dbo.Readers SET IsEditor = 0 WHERE Username = 'test_both';
+-- Revoke editor from test_both (use AspNetUserRoles / identity role assignment in production)
+-- UPDATE dbo.AspNetUserRoles ...
 GO
 
 -- Quick verification queries

--- a/School Blog project/Models/Readers.cs
+++ b/School Blog project/Models/Readers.cs
@@ -1,4 +1,6 @@
-﻿namespace School_Blog_project.Models
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace School_Blog_project.Models
 {
 	/// <summary>
 	/// Represents a reader record used for development and seed data.
@@ -8,6 +10,7 @@
 		/// <summary>
 		/// Primary key for the reader entry.
 		/// </summary>
+		[Key]
 		public int UserID { get; set; }
 
 		/// <summary>
@@ -19,17 +22,5 @@
 		/// Password placeholder for development seed data. Not used for authentication in production.
 		/// </summary>
 		public required string Password { get; set; }
-
-		/// <summary>
-		/// Indicates whether the reader has writer privileges (seed only).
-		/// </summary>
-		[Microsoft.AspNetCore.Mvc.ModelBinding.BindNever]
-		public bool IsWriter { get; set; }
-
-		/// <summary>
-		/// Indicates whether the reader has editor privileges (seed only).
-		/// </summary>
-		[Microsoft.AspNetCore.Mvc.ModelBinding.BindNever]
-		public bool IsEditor { get; set; }
 	}
 }

--- a/School Blog project/Program.cs
+++ b/School Blog project/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = false)
 	.AddRoles<IdentityRole>()
 	.AddEntityFrameworkStores<ApplicationDbContext>();
+builder.Services.AddScoped<RoleSeeder>();
 builder.Services.AddRazorPages();
 builder.Services.AddControllersWithViews();
 
@@ -45,5 +46,11 @@ app.MapControllerRoute(
 
 app.MapRazorPages()
    .WithStaticAssets();
+
+// NOTE: role and admin provisioning has been moved out of Program.cs.
+// See Data/AdminSeeder.cs for a helper that teams can edit and run manually to provision
+// initial roles and admin accounts for a deployment. This file intentionally does not
+// execute seeding automatically; call AdminSeeder.SeedAsync(...) from a deployment
+// script or a one-off tool when you need to provision initial accounts.
 
 app.Run();

--- a/School Blog project/School Blog project/Models/Reader.cs
+++ b/School Blog project/School Blog project/Models/Reader.cs
@@ -1,3 +1,6 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace School_Blog_project.Models
 {
 	/// <summary>
@@ -8,6 +11,8 @@ namespace School_Blog_project.Models
 		/// <summary>
 		/// Primary key for the reader.
 		/// </summary>
+		[Key]
+		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
 		public int UserID { get; set; }
 
 		/// <summary>

--- a/School Blog project/Views/Shared/_LoginPartial.cshtml
+++ b/School Blog project/Views/Shared/_LoginPartial.cshtml
@@ -14,6 +14,12 @@
             <button  type="submit" class="nav-link btn btn-link text-dark">Logout</button>
         </form>
     </li>
+    @if ((await UserManager.GetUserAsync(User)) is var appUser && appUser != null && await UserManager.IsInRoleAsync(appUser, "Writer"))
+    {
+        <li class="nav-item">
+            <a class="nav-link text-dark" asp-page="/WriterOnly/Index">Writer Area</a>
+        </li>
+    }
 }
 else
 {


### PR DESCRIPTION
Closes #44 

Migrated from boolean flags (`IsWriter`, `IsEditor`) on users and readers to ASP.NET Identity role-based authorization. Updated handlers, models, and database schema to remove these columns and use roles (`Reader`, `Writer`, `Editor`) instead. Added `RoleSeeder` for role creation at startup and `AdminSeeder` for manual admin/user provisioning. Registration now assigns the "Reader" role by default. Updated navigation and seed scripts to reflect these changes. Includes migration and code cleanups.