### PR TITLE
Upgrade EF Core to 10.0.7, schema and seed updates

### DIFF
--- a/School Blog project/Data/ApplicationDbContext.cs
+++ b/School Blog project/Data/ApplicationDbContext.cs
@@ -58,7 +58,7 @@ namespace School_Blog_project.Data
 			});
 
 			// Seed Articles (uses fixed DatePublished values to mirror SYSUTCDATETIME at insert time)
-			DateTime now = DateTime.UtcNow;
+			DateTime now = new DateTime(2026, 4, 27, 5, 52, 52, DateTimeKind.Utc);
 			// Ensure database column default
 			_ = builder.Entity<Article>().Property(a => a.IsFeatured).HasDefaultValue(false);
 

--- a/School Blog project/Data/Migrations/20260427065813_InitialCreate.Designer.cs
+++ b/School Blog project/Data/Migrations/20260427065813_InitialCreate.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using School_Blog_project.Data;
 
@@ -11,9 +12,11 @@ using School_Blog_project.Data;
 namespace School_Blog_project.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260427065813_InitialCreate")]
+    partial class InitialCreate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/School Blog project/Data/Migrations/20260427065813_InitialCreate.cs
+++ b/School Blog project/Data/Migrations/20260427065813_InitialCreate.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace School_Blog_project.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialCreate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsEditor",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "IsWriter",
+                table: "AspNetUsers");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsFeatured",
+                table: "Articles",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "Categories",
+                columns: table => new
+                {
+                    CatagoryId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ShortTitle = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: false),
+                    FullTitle = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Categories", x => x.CatagoryId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ArticleCatagories",
+                columns: table => new
+                {
+                    ArticleID = table.Column<int>(type: "int", nullable: false),
+                    CatagoryId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ArticleCatagories", x => new { x.ArticleID, x.CatagoryId });
+                    table.ForeignKey(
+                        name: "FK_ArticleCatagories_Articles_ArticleID",
+                        column: x => x.ArticleID,
+                        principalTable: "Articles",
+                        principalColumn: "ArticleID",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ArticleCatagories_Categories_CatagoryId",
+                        column: x => x.CatagoryId,
+                        principalTable: "Categories",
+                        principalColumn: "CatagoryId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 1,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 27, 5, 52, 52, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 2,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 27, 5, 52, 52, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 3,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 27, 5, 52, 52, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 4,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 27, 5, 52, 52, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 5,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 27, 5, 52, 52, 0, DateTimeKind.Utc));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ArticleCatagories_CatagoryId",
+                table: "ArticleCatagories",
+                column: "CatagoryId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ArticleCatagories");
+
+            migrationBuilder.DropTable(
+                name: "Categories");
+
+            migrationBuilder.DropColumn(
+                name: "IsFeatured",
+                table: "Articles");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsEditor",
+                table: "AspNetUsers",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsWriter",
+                table: "AspNetUsers",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 1,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 16, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 2,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 16, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 3,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 16, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 4,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 16, 0, 0, 0, 0, DateTimeKind.Utc));
+
+            migrationBuilder.UpdateData(
+                table: "Articles",
+                keyColumn: "ArticleID",
+                keyValue: 5,
+                column: "DatePublished",
+                value: new DateTime(2026, 4, 16, 0, 0, 0, 0, DateTimeKind.Utc));
+        }
+    }
+}

--- a/School Blog project/School Blog project.csproj
+++ b/School Blog project/School Blog project.csproj
@@ -9,11 +9,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #53 

This pull request introduces changes and updates to the Entity Framework Core migration and model snapshot files. The main focus is on changing the DateTime now value for the seed Articles to be a static value, and aligning the model with the latest EF Core conventions.

**Seed data and default values:**

* Updated the `DatePublished` seed values for articles to a fixed UTC date (`2026-04-27 05:52:52`) to ensure consistency. [[1]](diffhunk://#diff-c4a7418895d87e0faec26e73c745a55e3159158d714c34939514b9e9fcc9c472L61-R61) [[2]](diffhunk://#diff-70b2d3def83493fe307d12c8c02ff98675e36bcaceb8f2d856d8aa3d88ed9d0aR1-R171)

**Entity Framework Core model updates:**

Upgraded Entity Framework Core and ASP.NET Core Identity packages to 10.0.7. 