### PR TITLE
Added SiteSettings table

### DIFF
--- a/School Blog project/Data/ApplicationDbContext.cs
+++ b/School Blog project/Data/ApplicationDbContext.cs
@@ -16,10 +16,10 @@ namespace School_Blog_project.Data
 		/// </summary>
 		public DbSet<Article> Articles { get; set; } = null!;
 
-		/// <summary>
-        /// DbSet for reader seed records.
-		/// </summary>
-		public DbSet<School_Blog_project.Models.Reader> Readers { get; set; } = null!;
+		public DbSet<SiteSettings> SiteSettings { get; set; } = null!;
+		public DbSet<MediaContact> MediaContacts { get; set; } = null!;
+		public DbSet<ColorScheme> ColorSchemes { get; set; } = null!;
+		public DbSet<OffSiteLink> OffSiteLinks { get; set; } = null!;
 
 		public DbSet<ArticleCatagory> ArticleCatagories { get; set; } = null!;
 		public DbSet<Categories> Categories { get; set; } = null!;
@@ -31,15 +31,24 @@ namespace School_Blog_project.Data
 		{
 			base.OnModelCreating(builder);
 
-			// Seed Readers (matches Database/seed_dev.sql inserts and subsequent updates)
-			_ = builder.Entity<Reader>().HasData(
-				new Reader { UserID = 1, Username = "dev_alice", Password = "dev_pass_1", IsWriter = true, IsEditor = false },
-				new Reader { UserID = 2, Username = "dev_bob", Password = "dev_pass_2", IsWriter = false, IsEditor = true },
-				new Reader { UserID = 3, Username = "dev_carol", Password = "dev_pass_3", IsWriter = true, IsEditor = false }, // granted writer in SQL update
-				new Reader { UserID = 4, Username = "test_writer", Password = "dev_pass_4", IsWriter = true, IsEditor = false },
-				new Reader { UserID = 5, Username = "test_editor", Password = "dev_pass_5", IsWriter = false, IsEditor = true },
-				new Reader { UserID = 6, Username = "test_both", Password = "dev_pass_6", IsWriter = true, IsEditor = false } // editor revoked in SQL update
-			);
+			// SiteSettings relationships
+			_ = builder.Entity<SiteSettings>()
+				.HasOne(s => s.MediaContact)
+				.WithOne(mc => mc.SiteSettings)
+				.HasForeignKey<MediaContact>(mc => mc.SiteSettingsId)
+				.OnDelete(DeleteBehavior.Cascade);
+
+			_ = builder.Entity<SiteSettings>()
+				.HasOne(s => s.ColorScheme)
+				.WithOne(cs => cs.SiteSettings)
+				.HasForeignKey<ColorScheme>(cs => cs.SiteSettingsId)
+				.OnDelete(DeleteBehavior.Cascade);
+
+			_ = builder.Entity<SiteSettings>()
+				.HasMany(s => s.OffSiteLinks)
+				.WithOne(l => l.SiteSettings)
+				.HasForeignKey(l => l.SiteSettingsId)
+				.OnDelete(DeleteBehavior.Cascade);
 
 			// Configure the join entity ArticleCatagory: composite key and foreign keys
 			_ = builder.Entity<ArticleCatagory>(eb =>
@@ -58,7 +67,7 @@ namespace School_Blog_project.Data
 			});
 
 			// Seed Articles (uses fixed DatePublished values to mirror SYSUTCDATETIME at insert time)
-			DateTime now = new DateTime(2026, 4, 27, 5, 52, 52, DateTimeKind.Utc);
+			DateTime now = new(2026, 4, 27, 5, 52, 52, DateTimeKind.Utc);
 			// Ensure database column default
 			_ = builder.Entity<Article>().Property(a => a.IsFeatured).HasDefaultValue(false);
 

--- a/School Blog project/Migrations/20260430210123_AddSiteSettingsTables.Designer.cs
+++ b/School Blog project/Migrations/20260430210123_AddSiteSettingsTables.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using School_Blog_project.Data;
 
 #nullable disable
 
-namespace School_Blog_project.Data.Migrations
+namespace School_Blog_project.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430210123_AddSiteSettingsTables")]
+    partial class AddSiteSettingsTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/School Blog project/Migrations/20260430210123_AddSiteSettingsTables.cs
+++ b/School Blog project/Migrations/20260430210123_AddSiteSettingsTables.cs
@@ -1,0 +1,148 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace School_Blog_project.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSiteSettingsTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Readers");
+
+            migrationBuilder.CreateTable(
+                name: "SiteSettings",
+                columns: table => new
+                {
+                    SiteSettingsId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    StartYear = table.Column<int>(type: "int", nullable: false),
+                    SchoolName = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    SchoolAcronym = table.Column<string>(type: "nvarchar(10)", maxLength: 10, nullable: false),
+                    SchoolBlurb = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    SchoolLogo = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SchoolEmblem = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SiteSettings", x => x.SiteSettingsId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ColorSchemes",
+                columns: table => new
+                {
+                    SiteSettingsId = table.Column<int>(type: "int", nullable: false),
+                    Color1 = table.Column<string>(type: "nvarchar(6)", maxLength: 6, nullable: false),
+                    Color2 = table.Column<string>(type: "nvarchar(6)", maxLength: 6, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ColorSchemes", x => x.SiteSettingsId);
+                    table.ForeignKey(
+                        name: "FK_ColorSchemes_SiteSettings_SiteSettingsId",
+                        column: x => x.SiteSettingsId,
+                        principalTable: "SiteSettings",
+                        principalColumn: "SiteSettingsId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MediaContacts",
+                columns: table => new
+                {
+                    SiteSettingsId = table.Column<int>(type: "int", nullable: false),
+                    JobPosition = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: true),
+                    FullName = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: true),
+                    Phone = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: true),
+                    Email = table.Column<string>(type: "nvarchar(254)", maxLength: 254, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MediaContacts", x => x.SiteSettingsId);
+                    table.ForeignKey(
+                        name: "FK_MediaContacts_SiteSettings_SiteSettingsId",
+                        column: x => x.SiteSettingsId,
+                        principalTable: "SiteSettings",
+                        principalColumn: "SiteSettingsId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OffSiteLinks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SiteSettingsId = table.Column<int>(type: "int", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(80)", maxLength: 80, nullable: false),
+                    URL = table.Column<string>(type: "nvarchar(2083)", maxLength: 2083, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OffSiteLinks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OffSiteLinks_SiteSettings_SiteSettingsId",
+                        column: x => x.SiteSettingsId,
+                        principalTable: "SiteSettings",
+                        principalColumn: "SiteSettingsId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OffSiteLinks_SiteSettingsId",
+                table: "OffSiteLinks",
+                column: "SiteSettingsId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ColorSchemes");
+
+            migrationBuilder.DropTable(
+                name: "MediaContacts");
+
+            migrationBuilder.DropTable(
+                name: "OffSiteLinks");
+
+            migrationBuilder.DropTable(
+                name: "SiteSettings");
+
+            migrationBuilder.CreateTable(
+                name: "Readers",
+                columns: table => new
+                {
+                    UserID = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    IsEditor = table.Column<bool>(type: "bit", nullable: false),
+                    IsWriter = table.Column<bool>(type: "bit", nullable: false),
+                    Password = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Username = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Readers", x => x.UserID);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Readers",
+                columns: new[] { "UserID", "IsEditor", "IsWriter", "Password", "Username" },
+                values: new object[,]
+                {
+                    { 1, false, true, "dev_pass_1", "dev_alice" },
+                    { 2, true, false, "dev_pass_2", "dev_bob" },
+                    { 3, false, true, "dev_pass_3", "dev_carol" },
+                    { 4, false, true, "dev_pass_4", "test_writer" },
+                    { 5, true, false, "dev_pass_5", "test_editor" },
+                    { 6, false, true, "dev_pass_6", "test_both" }
+                });
+        }
+    }
+}

--- a/School Blog project/Models/SiteSettings.cs
+++ b/School Blog project/Models/SiteSettings.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace School_Blog_project.Models
+{
+	public class SiteSettings
+	{
+		[Key]
+		public int SiteSettingsId { get; set; }
+
+		[Required]
+		[Range(2010, 9999, ErrorMessage = "Year must be a 4-digit number >= 2010.")]
+		public int StartYear { get; set; } = 2010;
+
+		[Required]
+		[MaxLength(80)]
+		public string SchoolName { get; set; } = "School Name";
+
+		[Required]
+		[MaxLength(10)]
+		[RegularExpression("^[A-Za-z]+$", ErrorMessage = "Acronym must contain letters only.")]
+		public string SchoolAcronym { get; set; } = "ABCD";
+
+		[Required]
+		[MaxLength(500)]
+		public string SchoolBlurb { get; set; } = "Welcome to our blog!";
+
+		[Required]
+		public string SchoolLogo { get; set; } = "/images/placeholder-logo.png";
+
+		[Required]
+		public string SchoolEmblem { get; set; } = "/images/placeholder-emblem.png";
+
+		public MediaContact MediaContact { get; set; } = null!;
+		public ColorScheme ColorScheme { get; set; } = null!;
+		public ICollection<OffSiteLink> OffSiteLinks { get; set; } = [];
+	}
+
+	public class MediaContact
+	{
+		[Key, ForeignKey("SiteSettings")]
+		public int SiteSettingsId { get; set; }
+
+		[MaxLength(80)]
+		public string? JobPosition { get; set; }
+
+		[MaxLength(80)]
+		public string? FullName { get; set; }
+
+		[Phone]
+		[MaxLength(20)]
+		public string? Phone { get; set; }
+
+		[EmailAddress]
+		[MaxLength(254)]
+		public string? Email { get; set; }
+
+		public SiteSettings SiteSettings { get; set; } = null!;
+	}
+
+	public class ColorScheme
+	{
+		[Key, ForeignKey("SiteSettings")]
+		public int SiteSettingsId { get; set; }
+
+		[Required]
+		[StringLength(6, MinimumLength = 6)]
+		[RegularExpression("^[0-9A-Fa-f]{6}$", ErrorMessage = "Must be a 6-digit hex value.")]
+		public string Color1 { get; set; } = null!;
+
+		[Required]
+		[StringLength(6, MinimumLength = 6)]
+		[RegularExpression("^[0-9A-Fa-f]{6}$", ErrorMessage = "Must be a 6-digit hex value.")]
+		public string Color2 { get; set; } = null!;
+
+		public SiteSettings SiteSettings { get; set; } = null!;
+	}
+
+	public class OffSiteLink
+	{
+		[Key]
+		public int Id { get; set; }
+
+		[ForeignKey("SiteSettings")]
+		public int SiteSettingsId { get; set; }
+
+		[Required]
+		[MaxLength(80)]
+		public string Name { get; set; } = null!;
+
+		[Required]
+		[MaxLength(2083)]
+		[Url]
+		public string URL { get; set; } = null!;
+
+		public SiteSettings SiteSettings { get; set; } = null!;
+	}
+}

--- a/School Blog project/School Blog project.csproj
+++ b/School Blog project/School Blog project.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request introduces a new "Site Settings" feature to the project, replacing the previous "Reader" entity and seed data with a set of configuration tables for managing school branding, color schemes, media contact information, and off-site links. It includes new models, database schema changes, and updates to the Entity Framework context to support these features.

**Site Settings and Related Models**

- Added new models: `SiteSettings`, `MediaContact`, `ColorScheme`, and `OffSiteLink`, including validation attributes and relationships. These models allow for centralized management of school branding, contact, and appearance settings. (`School Blog project/Models/SiteSettings.cs`)

**Database Schema and Migrations**

- Created a new migration (`AddSiteSettingsTables`) that removes the `Readers` table and introduces new tables for `SiteSettings`, `ColorSchemes`, `MediaContacts`, and `OffSiteLinks`, with appropriate foreign key relationships and constraints. (`School Blog project/Migrations/20260430210123_AddSiteSettingsTables.cs`)
- Updated the model snapshot to reflect the new schema, including navigation properties and entity relationships for the new tables. (`School Blog project/Data/Migrations/ApplicationDbContextModelSnapshot.cs`) [[1]](diffhunk://#diff-fd4bf93f618388d576424013ebae292581eafcfd9936acadd9943f26fcfb63deL337-R447) [[2]](diffhunk://#diff-fd4bf93f618388d576424013ebae292581eafcfd9936acadd9943f26fcfb63deR520-R552) [[3]](diffhunk://#diff-fd4bf93f618388d576424013ebae292581eafcfd9936acadd9943f26fcfb63deR562-R572)

**Entity Framework Context Updates**

- Updated `ApplicationDbContext` to remove the `Readers` DbSet and add DbSets for the new models. Also, configured relationships between `SiteSettings` and its related entities in `OnModelCreating`. (`School Blog project/Data/ApplicationDbContext.cs`) [[1]](diffhunk://#diff-c4a7418895d87e0faec26e73c745a55e3159158d714c34939514b9e9fcc9c472L19-R22) [[2]](diffhunk://#diff-c4a7418895d87e0faec26e73c745a55e3159158d714c34939514b9e9fcc9c472L34-R51)

**Other Changes**

- Added the `Microsoft.EntityFrameworkCore.InMemory` package reference for improved testing support. (`School Blog project/School Blog project.csproj`)

**Minor Improvements**

- Minor code style update for `DateTime` initialization. (`School Blog project/Data/ApplicationDbContext.cs`)